### PR TITLE
Change OpenSSL package for RHEL 8

### DIFF
--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -2,7 +2,7 @@
 # packages (versions)
 openssl_packages:
   - openssl
-  - python-openssl
+  - python3-pyOpenSSL
   - ca-certificates
 # pip executable
 openssl_pip_executable: /usr/bin/pip


### PR DESCRIPTION
Hey!

I tested this role on RHEL 8 and got problems with the OpenSSL package. It wouldn't find the package as is:

`- python-openssl`

Now with RHEL8 you need to specify what version of pyhton is going to be used (in this case, python3)

According with the documentation of RHEL 8, the correct name is: 

` - python3-pyOpenSSL`

With this change, I managed to test and it worked perfectly. 
